### PR TITLE
["1", "2", "3"].map(parseInt) 答案是多少？

### DIFF
--- a/Front-end-Developer-Questions/Questions-and-Answers/README.md
+++ b/Front-end-Developer-Questions/Questions-and-Answers/README.md
@@ -543,7 +543,7 @@ HTML5？
 	
 -  ["1", "2", "3"].map(parseInt) 答案是多少？
 
-		 [1, NaN, NaN] 因为 parseInt 需要两个参数 (val, radix) 但 map 传了 3 个 (element, index, array)
+		 [1, NaN, NaN] 因为 parseInt 需要两个参数 (val, radix)，其中 radix 表示解析时用的基数。map 传了 3 个 (element, index, array)，对应的 radix 不合法导致解析失败。
 
 -  如何创建一个对象? （画出此对象的内存图）
 


### PR DESCRIPTION
原因是 radix 参数不合法，而不是参数个数不符。
